### PR TITLE
Remove ß symbol from parallax widget.

### DIFF
--- a/modules/hp_parallax/templates/paragraph--hp-parallax.html.twig
+++ b/modules/hp_parallax/templates/paragraph--hp-parallax.html.twig
@@ -38,5 +38,5 @@
 		</div>
 	{% if hp_show_wrapper %}
     </section>
-  ß{% endif %}
+  {% endif %}
 </section>


### PR DESCRIPTION
**Changes**
- Removed ß symbol from parallax widget.

**How Verified**
- Confirmed the symbol was removed from the dev.finearts.howard.edu website.